### PR TITLE
뉴스 기사 말뭉치 sanitizer (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,19 @@ pip install moducorpus_sanitizer
 moducorpus news \
   --input_dir ~/local/modu/National_Institute_Korean_Language/NIKL_NEWSPAPER\(v1.0\) \
   --output_dir ~/local/modu/sanitizer/NIKL_NEWSPAPER/ \
+  --corpus type multiline \
   --field title paragraph
+
+moducorpus news \
+  --input_dir ~/local/modu/National_Institute_Korean_Language/NIKL_NEWSPAPER\(v1.0\) \
+  --output_dir ~/local/modu/sanitizer/NIKL_NEWSPAPER/ \
+  --corpus type doublespaceline \
+  --field title paragraph topic
 ```
+
+| Arguments | values |
+| --- | --- |
+| input_dir | path/to/NIKL_NEWSPAPER(v1.0) |
+| output_dir | path/to/corpus/NIKL_NEWSPAPER |
+| type | 다음 값 중 한가지 선택 ['multiline', 'doublespaceline' |
+| fields | 다음 값 중 중복 선택 ['title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'] |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # moducorpus-sanitizer: 모두의 말뭉치 정제
+
+## Install
+
+(from source)
+```
+git clone https://github.com/ko-nlp/moducorpus-sanitizer
+cd moducorpus-sanitizer
+python setup.py install
+```
+
+(with pip)
+```
+pip install moducorpus_sanitizer
+```
+
+## 모두의 말뭉치: 뉴스 말뭉치
+
+```
+moducorpus news \
+  --input_dir ~/local/modu/National_Institute_Korean_Language/NIKL_NEWSPAPER\(v1.0\) \
+  --output_dir ~/local/modu/sanitizer/NIKL_NEWSPAPER/ \
+  --field title paragraph
+```

--- a/moducorpus_sanitizer/cli.py
+++ b/moducorpus_sanitizer/cli.py
@@ -20,6 +20,7 @@ def show_arguments(args):
 
 def main():
     parser = argparse.ArgumentParser(description='moducorpus-sanitizer Command Line Interface')
+    parser.add_argument('--debug', dest='debug', action='store_true')
     parser.set_defaults(func=show_version)
     subparsers = parser.add_subparsers(help='moducorpus_sanitizer')
 
@@ -31,7 +32,7 @@ def main():
     parser_news.add_argument('--input_dir', required=True, type=str, help='path/to/NIKL_NEWSPAPER(v1.0)')
     parser_news.add_argument('--output_dir', required=True, type=str, help='path/to/corpus/NIKL_NEWSPAPER(v1.0)')
     parser_news.add_argument('--type', type=str, default='doublespaceline', choices=['multiline', 'doublespaceline'])
-    parser_news.add_argument('--fields', type=str, nargs='+', default=['title', 'paragraph'], choices=['title', 'paragraph'])
+    parser_news.add_argument('--fields', type=str, nargs='+', default=['title', 'paragraph'], choices=['title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'])
     parser_news.set_defaults(func=news_to_corpus)
 
     # Do task

--- a/moducorpus_sanitizer/modu_news.py
+++ b/moducorpus_sanitizer/modu_news.py
@@ -4,7 +4,7 @@ from glob import glob
 from tqdm import tqdm
 from typing import List
 
-from .utils import check_dir, check_fields
+from .utils import append, check_dir, check_fields
 
 
 # document_id is default
@@ -26,17 +26,12 @@ def news_to_corpus(args):
     if args.debug:  # DEVELOP CODE
         paths = paths[:3]
 
-    for documents in iterate_files(paths):
+    for i_doc, documents in enumerate(iterate_files(paths)):
+        mode = 'w' if i_doc == 0 else 'a'
         for field in fields:
             path = field_to_file[field]
             values = [getattr(doc, field) for doc in documents]
-            append(path, values)
-
-
-def append(path, data):
-    with open(path, 'a', encoding='utf-8') as f:
-        for row in data:
-            f.write(f'{row}\n')
+            append(path, values, mode)
 
 
 @dataclass

--- a/moducorpus_sanitizer/modu_news.py
+++ b/moducorpus_sanitizer/modu_news.py
@@ -11,27 +11,46 @@ from .utils import append, check_dir, check_fields
 AVAILABLE_FIELDS = {'title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'}
 
 def news_to_corpus(args):
+    # List-up arguments
     input_dir = args.input_dir
     output_dir = args.output_dir
     corpus_type = args.type
     fields = args.fields
 
+    # Check fields
     fields = check_fields(fields, AVAILABLE_FIELDS)
     fields.append('document_id')
 
+    # Prepare output paths
     check_dir(output_dir)
-
     field_to_file = {field: f'{output_dir}/{field}.txt' for field in fields}
+
+    # Prepare input files
     paths = sorted(glob(f'{input_dir}/N*RW*.json'))
     if args.debug:  # DEVELOP CODE
         paths = paths[:3]
 
-    for i_doc, documents in enumerate(iterate_files(paths)):
+    # Set paragraph format
+    if corpus_type == 'doublespaceline':
+        paragraph_formatter = to_doublespaceline
+    else:
+        paragraph_formatter = to_multiline
+
+    # Do sanitization
+    for i_doc, documents in enumerate(iterate_files(paths, paragraph_formatter)):
         mode = 'w' if i_doc == 0 else 'a'
         for field in fields:
             path = field_to_file[field]
             values = [getattr(doc, field) for doc in documents]
             append(path, values, mode)
+
+
+def to_multiline(lines):
+    return '\n'.join(lines) + '\n'
+
+
+def to_doublespaceline(lines):
+    return '  '.join(lines)
 
 
 @dataclass
@@ -46,7 +65,7 @@ class ModuNews:
     paragraph: List[str]
 
 
-def document_to_a_news(document):
+def document_to_a_news(document, paragraph_formatter):
     document_id = document['id']
     meta = document['metadata']
     title = meta['title']
@@ -55,11 +74,11 @@ def document_to_a_news(document):
     date = meta['date']
     topic = meta['topic']
     original_topic = meta['original_topic']
-    paragraph = [p['form'] for p in document['paragraph']]
+    paragraph = paragraph_formatter([p['form'] for p in document['paragraph']])
     return ModuNews(document_id, title, author, publisher, date, topic, original_topic, paragraph)
 
 
-def iterate_files(paths):
+def iterate_files(paths, paragraph_formatter):
     news = []
     for i_path, path in enumerate(paths):
         with open(path, encoding='utf-8') as f:
@@ -67,5 +86,5 @@ def iterate_files(paths):
         documents = data['document']
         desc = f'Transform to ModuNews {i_path + 1}/{len(paths)} files'
         total = len(documents)
-        documents = [document_to_a_news(doc) for doc in tqdm(documents, desc=desc, total=total)]
+        documents = [document_to_a_news(doc, paragraph_formatter) for doc in tqdm(documents, desc=desc, total=total)]
         yield documents

--- a/moducorpus_sanitizer/modu_news.py
+++ b/moducorpus_sanitizer/modu_news.py
@@ -4,14 +4,18 @@ from glob import glob
 from tqdm import tqdm
 from typing import List
 
-from .utils import check_dir
+from .utils import check_dir, check_fields
 
+
+# document_id is default
+AVAILABLE_FIELDS = {'title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'}
 
 def news_to_corpus(args):
     input_dir = args.input_dir
     output_dir = args.output_dir
     corpus_type = args.type
     fields = args.fields
+    fields = check_fields(fields, AVAILABLE_FIELDS)
 
     check_dir(output_dir)
 
@@ -36,7 +40,6 @@ def append(path, data):
 class ModuNews:
     document_id: str
     title: str
-    author: str
     author: str
     publisher: str
     date: str

--- a/moducorpus_sanitizer/modu_news.py
+++ b/moducorpus_sanitizer/modu_news.py
@@ -15,19 +15,22 @@ def news_to_corpus(args):
     output_dir = args.output_dir
     corpus_type = args.type
     fields = args.fields
+
     fields = check_fields(fields, AVAILABLE_FIELDS)
+    fields.append('document_id')
 
     check_dir(output_dir)
 
     field_to_file = {field: f'{output_dir}/{field}.txt' for field in fields}
     paths = sorted(glob(f'{input_dir}/N*RW*.json'))
-    paths = paths[:1]  # DEVELOP CODE
+    if args.debug:  # DEVELOP CODE
+        paths = paths[:3]
 
     for documents in iterate_files(paths):
-        titles = [doc.title for doc in documents]
-        paragraphs = ['  '.join(doc.paragraph) for doc in documents]
-        append(field_to_file['title'], titles)
-        append(field_to_file['paragraph'], paragraphs)
+        for field in fields:
+            path = field_to_file[field]
+            values = [getattr(doc, field) for doc in documents]
+            append(path, values)
 
 
 def append(path, data):
@@ -67,7 +70,7 @@ def iterate_files(paths):
         with open(path, encoding='utf-8') as f:
             data = json.load(f)
         documents = data['document']
-        desc = f'Transform to ModuNews {i_path}/{len(paths)} files'
+        desc = f'Transform to ModuNews {i_path + 1}/{len(paths)} files'
         total = len(documents)
         documents = [document_to_a_news(doc) for doc in tqdm(documents, desc=desc, total=total)]
         yield documents

--- a/moducorpus_sanitizer/utils.py
+++ b/moducorpus_sanitizer/utils.py
@@ -3,3 +3,13 @@ import os
 
 def check_dir(dirname):
     os.makedirs(os.path.abspath(dirname), exist_ok=True)
+
+
+def check_fields(inputs, available_fields):
+    checked = []
+    for input in sorted(inputs):
+        if input not in available_fields:
+            print(f'Found wrong field `{input}`. Sanitizer ignore the field')
+        else:
+            checked.append(input)
+    return checked

--- a/moducorpus_sanitizer/utils.py
+++ b/moducorpus_sanitizer/utils.py
@@ -1,6 +1,12 @@
 import os
 
 
+def append(path, data, mode):
+    with open(path, mode, encoding='utf-8') as f:
+        for row in data:
+            f.write(f'{row}\n')
+
+
 def check_dir(dirname):
     os.makedirs(os.path.abspath(dirname), exist_ok=True)
 


### PR DESCRIPTION
모두의 말뭉치: 뉴스 말뭉치를 텍스트 파일로 정제합니다. 각 필드별로 `output_dir/FIELD.txt` 파일에 저장됩니다.