### PR TITLE
뉴스 기사 말뭉치 sanitizer: 저장 포멧 변경 #3

### DIFF
--- a/moducorpus_sanitizer/cli.py
+++ b/moducorpus_sanitizer/cli.py
@@ -21,20 +21,22 @@ def show_arguments(args):
 
 def main():
     parser = argparse.ArgumentParser(description='moducorpus-sanitizer Command Line Interface')
-    parser.add_argument('--debug', dest='debug', action='store_true')
     parser.set_defaults(func=show_version)
     subparsers = parser.add_subparsers(help='moducorpus_sanitizer')
+
+    commons = argparse.ArgumentParser(add_help=False)
+    commons.add_argument('--debug', dest='debug', action='store_true')
+    commons.add_argument('--text_only', dest='text_only', action='store_true')
 
     # version
     parser_version = subparsers.add_parser('version', help='Show version')
 
     # News
-    parser_news = subparsers.add_parser('news', help='News corpus')
-    parser_news.add_argument('--input_dir', required=True, type=str, help='path/to/NIKL_NEWSPAPER(v1.0)')
-    parser_news.add_argument('--output_dir', required=True, type=str,
+    parser_news = subparsers.add_parser('news', parents=[commons], help='News corpus')
+    parser_news.add_argument("-i", "--input_dir", required=True, type=str, help='path/to/NIKL_NEWSPAPER(v1.0)')
+    parser_news.add_argument("-o", "--output_dir", required=True, type=str,
                              help='path/to/corpus/ It creates `NIKL_NEWSPAPER` subdirectory automatically')
-    parser_news.add_argument('--type', type=str, default='doublespaceline', choices=['multiline', 'doublespaceline'])
-    parser_news.add_argument('--fields', type=str, nargs='+', default=['title', 'paragraph'], choices=['title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'])
+    parser_news.add_argument("--fields", type=str, nargs='+', default=['title', 'paragraph'], choices=['title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'])
     parser_news.set_defaults(func=news_to_corpus)
 
     # Messenger

--- a/moducorpus_sanitizer/modu_newspaper.py
+++ b/moducorpus_sanitizer/modu_newspaper.py
@@ -69,11 +69,10 @@ def document_to_a_news(document):
 
 
 def iterate_files(paths):
-    for i_path, path in enumerate(paths):
+    for path in tqdm(paths, total=len(paths), position=1, leave=True, desc="Transform to ModuNews"):
         with open(path, encoding='utf-8') as f:
             data = json.load(f)
         documents = data['document']
-        desc = f'Transform to ModuNews {i_path + 1}/{len(paths)} files'
         total = len(documents)
-        documents = [document_to_a_news(doc) for doc in tqdm(documents, desc=desc, total=total)]
+        documents = [document_to_a_news(doc) for doc in tqdm(documents, total=total, position=0,leave=False)]
         yield documents

--- a/moducorpus_sanitizer/modu_newspaper.py
+++ b/moducorpus_sanitizer/modu_newspaper.py
@@ -12,6 +12,12 @@ from .utils import append, check_dir, check_fields
 AVAILABLE_FIELDS = {'title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'}
 
 def news_to_corpus(args):
+    def to_multiline(lines):
+        return '\n'.join(lines)
+
+    def to_doublespaceline(lines):
+        return '  '.join(lines)
+
     # List-up arguments
     input_dir = args.input_dir
     output_dir = os.path.join(args.output_dir, 'NIKL_NEWSPAPER')
@@ -44,14 +50,6 @@ def news_to_corpus(args):
             path = field_to_file[field]
             values = [getattr(doc, field) for doc in documents]
             append(path, values, mode)
-
-
-def to_multiline(lines):
-    return '\n'.join(lines) + '\n'
-
-
-def to_doublespaceline(lines):
-    return '  '.join(lines)
 
 
 @dataclass

--- a/moducorpus_sanitizer/modu_newspaper.py
+++ b/moducorpus_sanitizer/modu_newspaper.py
@@ -5,51 +5,42 @@ from glob import glob
 from tqdm import tqdm
 from typing import List
 
-from .utils import append, check_dir, check_fields
+from .utils import check_dir, check_fields
 
 
 # document_id is default
 AVAILABLE_FIELDS = {'title', 'author', 'publisher', 'date', 'topic', 'original_topic', 'paragraph'}
 
 def news_to_corpus(args):
-    def to_multiline(lines):
-        return '\n'.join(lines)
-
-    def to_doublespaceline(lines):
-        return '  '.join(lines)
-
     # List-up arguments
     input_dir = args.input_dir
-    output_dir = os.path.join(args.output_dir, 'NIKL_NEWSPAPER')
-    corpus_type = args.type
+    check_dir(args.output_dir)
+    if args.text_only:
+        output_file = os.path.join(args.output_dir, 'NIKL_NEWSPAPER.text')
+    else:
+        output_file = os.path.join(args.output_dir, 'NIKL_NEWSPAPER.jsonl')
     fields = args.fields
 
     # Check fields
     fields = check_fields(fields, AVAILABLE_FIELDS)
     fields.append('document_id')
 
-    # Prepare output paths
-    check_dir(output_dir)
-    field_to_file = {field: f'{output_dir}/{field}.txt' for field in fields}
-
     # Prepare input files
     paths = sorted(glob(f'{input_dir}/N*RW*.json'))
     if args.debug:  # DEVELOP CODE
         paths = paths[:3]
 
-    # Set paragraph format
-    if corpus_type == 'doublespaceline':
-        paragraph_formatter = to_doublespaceline
-    else:
-        paragraph_formatter = to_multiline
-
     # Do sanitization
-    for i_doc, documents in enumerate(iterate_files(paths, paragraph_formatter)):
+    for i_doc, documents in enumerate(iterate_files(paths)):
         mode = 'w' if i_doc == 0 else 'a'
-        for field in fields:
-            path = field_to_file[field]
-            values = [getattr(doc, field) for doc in documents]
-            append(path, values, mode)
+        with open(output_file, mode) as f:
+            if args.text_only:
+                for doc in documents:
+                    f.write(getattr(doc, "paragraph") + "\n")
+            else:
+                for doc in documents:
+                    selected = {field: getattr(doc, field) for field in fields}
+                    f.write(json.dumps(selected, ensure_ascii=False) + "\n")
 
 
 @dataclass
@@ -61,10 +52,10 @@ class ModuNews:
     date: str
     topic: str
     original_topic: str
-    paragraph: List[str]
+    paragraph: str
 
 
-def document_to_a_news(document, paragraph_formatter):
+def document_to_a_news(document):
     document_id = document['id']
     meta = document['metadata']
     title = meta['title']
@@ -73,16 +64,16 @@ def document_to_a_news(document, paragraph_formatter):
     date = meta['date']
     topic = meta['topic']
     original_topic = meta['original_topic']
-    paragraph = paragraph_formatter([p['form'] for p in document['paragraph']])
+    paragraph = "\n".join([p['form'] for p in document['paragraph']])
     return ModuNews(document_id, title, author, publisher, date, topic, original_topic, paragraph)
 
 
-def iterate_files(paths, paragraph_formatter):
+def iterate_files(paths):
     for i_path, path in enumerate(paths):
         with open(path, encoding='utf-8') as f:
             data = json.load(f)
         documents = data['document']
         desc = f'Transform to ModuNews {i_path + 1}/{len(paths)} files'
         total = len(documents)
-        documents = [document_to_a_news(doc, paragraph_formatter) for doc in tqdm(documents, desc=desc, total=total)]
+        documents = [document_to_a_news(doc) for doc in tqdm(documents, desc=desc, total=total)]
         yield documents


### PR DESCRIPTION
Resolve #3 

- 데이터 저장 형식으로 JSON list 을 지원함으로써 뉴스 기사의 타이틀을 가져올 수 있도록 함
- `--text_only` 옵션을 둠으로써 텍스트만 필요한 경우 `*.text` 파일로 본문만을 저장하도록 함